### PR TITLE
Move extracted_primary_ip* on top of _fill_host_variables

### DIFF
--- a/plugins/inventory/nb_inventory.py
+++ b/plugins/inventory/nb_inventory.py
@@ -1306,6 +1306,18 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             )
 
     def _fill_host_variables(self, host, hostname):
+        extracted_primary_ip = self.extract_primary_ip(host=host)
+        if extracted_primary_ip:
+            self.inventory.set_variable(hostname, "ansible_host", extracted_primary_ip)
+
+        extracted_primary_ip4 = self.extract_primary_ip4(host=host)
+        if extracted_primary_ip4:
+            self.inventory.set_variable(hostname, "primary_ip4", extracted_primary_ip4)
+
+        extracted_primary_ip6 = self.extract_primary_ip6(host=host)
+        if extracted_primary_ip6:
+            self.inventory.set_variable(hostname, "primary_ip6", extracted_primary_ip6)
+
         for attribute, extractor in self.group_extractors.items():
             extracted_value = extractor(host)
 
@@ -1337,18 +1349,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     self.inventory.set_variable(hostname, key, value)
             else:
                 self.inventory.set_variable(hostname, attribute, extracted_value)
-
-        extracted_primary_ip = self.extract_primary_ip(host=host)
-        if extracted_primary_ip:
-            self.inventory.set_variable(hostname, "ansible_host", extracted_primary_ip)
-
-        extracted_primary_ip4 = self.extract_primary_ip4(host=host)
-        if extracted_primary_ip4:
-            self.inventory.set_variable(hostname, "primary_ip4", extracted_primary_ip4)
-
-        extracted_primary_ip6 = self.extract_primary_ip6(host=host)
-        if extracted_primary_ip6:
-            self.inventory.set_variable(hostname, "primary_ip6", extracted_primary_ip6)
 
     def _get_host_virtual_chassis_master(self, host):
         virtual_chassis = host.get("virtual_chassis", None)


### PR DESCRIPTION
This patch allows overriding ansible_host variable via a config_context or custom_field
Sometimes the primary ip of a device/vm does not match the one that ansible should use to manage it (eg nat, management network ecc)